### PR TITLE
Only platform admins and center admin users can create a new centro de investigacion

### DIFF
--- a/app/controllers/admin_center/confirmations_controller.rb
+++ b/app/controllers/admin_center/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AdminCenter::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/admin_center/omniauth_callbacks_controller.rb
+++ b/app/controllers/admin_center/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AdminCenter::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/admin_center/passwords_controller.rb
+++ b/app/controllers/admin_center/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class AdminCenter::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/admin_center/registrations_controller.rb
+++ b/app/controllers/admin_center/registrations_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class AdminCenter::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+  include Accessible
+  # Allow current users to edit and cancel their own accounts.
+  skip_before_action :check_user, except: [:new, :create]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/admin_center/sessions_controller.rb
+++ b/app/controllers/admin_center/sessions_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AdminCenter::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+  include Accessible
+  skip_before_action :check_user, only: :destroy
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/admin_center/unlocks_controller.rb
+++ b/app/controllers/admin_center/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AdminCenter::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/admin_platform/confirmations_controller.rb
+++ b/app/controllers/admin_platform/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AdminPlatform::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/admin_platform/omniauth_callbacks_controller.rb
+++ b/app/controllers/admin_platform/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AdminPlatform::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/admin_platform/passwords_controller.rb
+++ b/app/controllers/admin_platform/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class AdminPlatform::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/admin_platform/registrations_controller.rb
+++ b/app/controllers/admin_platform/registrations_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+include Accessible
+
+class AdminPlatform::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+  include Accessible
+  # Allow current users to edit and cancel their own accounts.
+  skip_before_action :check_user, except: [:new, :create]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/admin_platform/sessions_controller.rb
+++ b/app/controllers/admin_platform/sessions_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AdminPlatform::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+  include Accessible
+  skip_before_action :check_user, only: :destroy
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/admin_platform/unlocks_controller.rb
+++ b/app/controllers/admin_platform/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AdminPlatform::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/centers_controller.rb
+++ b/app/controllers/centers_controller.rb
@@ -3,6 +3,12 @@
 class CentersController < ApplicationController
   before_action :set_center, only: %i[show edit update destroy]
 
+  before_action :only => [:new, :edit] do
+    redirect_to new_admin_platform_session_path unless current_admin_platform or current_admin_center
+    # TODO: Pass ID of the Centro de Investigación that's linked with this admin account.
+    redirect_to edit_center_path(id: 3) unless not current_admin_platform && current_admin_center.try(:has_created_center?)
+  end
+
   # GET /centers
   # GET /centers.json
   def index

--- a/app/controllers/concerns/accessible.rb
+++ b/app/controllers/concerns/accessible.rb
@@ -1,0 +1,21 @@
+module Accessible
+  extend ActiveSupport::Concern
+  included do
+    before_action :check_user
+  end
+
+  protected
+  def check_user
+    # Redirect and return any user that is trying to access
+    # pages that are not specific to the type of user they are.
+    if current_admin_platform
+      flash.clear
+      # if you have rails_admin. You can redirect anywhere really
+      redirect_to(rails_admin.dashboard_path) && return
+    elsif current_user
+      flash.clear
+      # The authenticated root path can be defined in your routes.rb in: devise_scope :user do...
+      redirect_to(authenticated_user_root_path) && return
+    end
+  end
+end

--- a/app/models/admin_center.rb
+++ b/app/models/admin_center.rb
@@ -1,0 +1,6 @@
+class AdminCenter < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end

--- a/app/models/admin_platform.rb
+++ b/app/models/admin_platform.rb
@@ -1,0 +1,6 @@
+class AdminPlatform < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end

--- a/app/views/admin_centers/confirmations/new.html.erb
+++ b/app/views/admin_centers/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "admin_centers/shared/links" %>

--- a/app/views/admin_centers/mailer/confirmation_instructions.html.erb
+++ b/app/views/admin_centers/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/admin_centers/mailer/email_changed.html.erb
+++ b/app/views/admin_centers/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/admin_centers/mailer/password_change.html.erb
+++ b/app/views/admin_centers/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/admin_centers/mailer/reset_password_instructions.html.erb
+++ b/app/views/admin_centers/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/admin_centers/mailer/unlock_instructions.html.erb
+++ b/app/views/admin_centers/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/admin_centers/passwords/edit.html.erb
+++ b/app/views/admin_centers/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "admin_centers/shared/links" %>

--- a/app/views/admin_centers/passwords/new.html.erb
+++ b/app/views/admin_centers/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "admin_centers/shared/links" %>

--- a/app/views/admin_centers/registrations/edit.html.erb
+++ b/app/views/admin_centers/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/admin_centers/registrations/new.html.erb
+++ b/app/views/admin_centers/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Registro Admin Centro de Investigación</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "admin_centers/shared/links" %>

--- a/app/views/admin_centers/sessions/new.html.erb
+++ b/app/views/admin_centers/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Iniciar Sesión Admin Centro de Investigación</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "admin_centers/shared/links" %>

--- a/app/views/admin_centers/shared/_error_messages.html.erb
+++ b/app/views/admin_centers/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/admin_centers/shared/_links.html.erb
+++ b/app/views/admin_centers/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+  <% end %>
+<% end %>

--- a/app/views/admin_centers/unlocks/new.html.erb
+++ b/app/views/admin_centers/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "admin_centers/shared/links" %>

--- a/app/views/admin_platforms/confirmations/new.html.erb
+++ b/app/views/admin_platforms/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "admin_platforms/shared/links" %>

--- a/app/views/admin_platforms/mailer/confirmation_instructions.html.erb
+++ b/app/views/admin_platforms/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/admin_platforms/mailer/email_changed.html.erb
+++ b/app/views/admin_platforms/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/admin_platforms/mailer/password_change.html.erb
+++ b/app/views/admin_platforms/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/admin_platforms/mailer/reset_password_instructions.html.erb
+++ b/app/views/admin_platforms/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/admin_platforms/mailer/unlock_instructions.html.erb
+++ b/app/views/admin_platforms/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/admin_platforms/passwords/edit.html.erb
+++ b/app/views/admin_platforms/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "admin_platforms/shared/links" %>

--- a/app/views/admin_platforms/passwords/new.html.erb
+++ b/app/views/admin_platforms/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "admin_platforms/shared/links" %>

--- a/app/views/admin_platforms/registrations/edit.html.erb
+++ b/app/views/admin_platforms/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/admin_platforms/registrations/new.html.erb
+++ b/app/views/admin_platforms/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Registro Admin Plataforma</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "admin_platforms/shared/links" %>

--- a/app/views/admin_platforms/sessions/new.html.erb
+++ b/app/views/admin_platforms/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Iniciar Sesión Admin Plataforma</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "admin_platforms/shared/links" %>

--- a/app/views/admin_platforms/shared/_error_messages.html.erb
+++ b/app/views/admin_platforms/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/admin_platforms/shared/_links.html.erb
+++ b/app/views/admin_platforms/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+  <% end %>
+<% end %>

--- a/app/views/admin_platforms/unlocks/new.html.erb
+++ b/app/views/admin_platforms/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "admin_platforms/shared/links" %>

--- a/app/views/usuarios/inicio.html.erb
+++ b/app/views/usuarios/inicio.html.erb
@@ -1,6 +1,6 @@
 <h1>Usuarios#inicio</h1>
 
-<% if current_user %>
+<% if current_user or current_admin_platform or current_admin_center %>
 
 <%= link_to 'Cerrar Sesión', destroy_user_session_path, method: :delete %>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -232,7 +232,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,6 +3,8 @@
 en:
   devise:
     confirmations:
+      admin_platforms_user:
+        confirmed: "Your ADMIN email address has been successfully confirmed."
       confirmed: "Your email address has been successfully confirmed."
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  devise_for :admin_platforms, path: 'admin_plataforma', controllers: {
+    # sessions: 'sessions'
+  }
+  devise_for :admin_centers, path: 'admin_centro', controllers: {
+    # sessions: 'admin_centers/sessions'
+  }
   resources :idti_areas
   resources :idti_services
   resources :centro_investigacions

--- a/db/migrate/20191019014217_devise_create_admin_centers.rb
+++ b/db/migrate/20191019014217_devise_create_admin_centers.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateAdminCenters < ActiveRecord::Migration[5.2]
+  def change
+    create_table :admin_centers do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :admin_centers, :email,                unique: true
+    add_index :admin_centers, :reset_password_token, unique: true
+    # add_index :admin_centers, :confirmation_token,   unique: true
+    # add_index :admin_centers, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20191019014624_devise_create_admin_platforms.rb
+++ b/db/migrate/20191019014624_devise_create_admin_platforms.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateAdminPlatforms < ActiveRecord::Migration[5.2]
+  def change
+    create_table :admin_platforms do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :admin_platforms, :email,                unique: true
+    add_index :admin_platforms, :reset_password_token, unique: true
+    # add_index :admin_platforms, :confirmation_token,   unique: true
+    # add_index :admin_platforms, :unlock_token,         unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,123 +10,200 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_009_224_604) do
-  create_table 'awards', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.date 'date'
-    t.bigint 'center_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['center_id'], name: 'index_awards_on_center_id'
+ActiveRecord::Schema.define(version: 2019_10_19_024055) do
+
+  create_table "admin_centers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "has_created_center"
+    t.index ["email"], name: "index_admin_centers_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admin_centers_on_reset_password_token", unique: true
   end
 
-  create_table 'centers', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'full_name'
-    t.string 'short_name'
-    t.string 'website'
-    t.string 'address'
-    t.date 'start_date'
-    t.float 'building_area'
-    t.float 'property_area'
-    t.float 'property_private_funding'
-    t.float 'property_federal_funding'
-    t.float 'property_state_funding'
-    t.float 'property_other_funding'
-    t.string 'property_other_source'
-    t.float 'equipment_private_funding'
-    t.float 'equipment_federal_funding'
-    t.float 'equipment_state_funding'
-    t.float 'equipment_other_funding'
-    t.string 'equipment_other_source'
-    t.integer 'requested_patents_mexico'
-    t.integer 'requested_designs_mexico'
-    t.integer 'requested_patents_us_eu_as'
-    t.integer 'given_patents_mexico'
-    t.integer 'given_designs_mexico'
-    t.integer 'given_patents_us_eu_as'
-    t.integer 'trademarks'
-    t.integer 'copyrights'
-    t.integer 'isi_publications'
-    t.integer 'arbitrated_publications'
-    t.integer 'non_arbitrated_publications'
-    t.integer 'quotes_in_publications'
-    t.string 'director_name'
-    t.string 'director_email'
-    t.string 'director_phone'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'transfer_office_contact_name'
-    t.string 'transfer_office_contact'
+  create_table "admin_platforms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admin_platforms_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admin_platforms_on_reset_password_token", unique: true
   end
 
-  create_table 'centers_clusters', id: false, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'cluster_id', null: false
-    t.bigint 'center_id', null: false
-    t.index ['center_id'], name: 'index_centers_clusters_on_center_id'
-    t.index ['cluster_id'], name: 'index_centers_clusters_on_cluster_id'
+  create_table "awards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.date "date"
+    t.bigint "center_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["center_id"], name: "index_awards_on_center_id"
   end
 
-  create_table 'centers_industries', id: false, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'industry_id', null: false
-    t.bigint 'center_id', null: false
-    t.index ['center_id'], name: 'index_centers_industries_on_center_id'
-    t.index ['industry_id'], name: 'index_centers_industries_on_industry_id'
+  create_table "centers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "full_name"
+    t.string "short_name"
+    t.string "website"
+    t.string "address"
+    t.date "start_date"
+    t.float "building_area"
+    t.float "property_area"
+    t.float "property_private_funding"
+    t.float "property_federal_funding"
+    t.float "property_state_funding"
+    t.float "property_other_funding"
+    t.string "property_other_source"
+    t.float "equipment_private_funding"
+    t.float "equipment_federal_funding"
+    t.float "equipment_state_funding"
+    t.float "equipment_other_funding"
+    t.string "equipment_other_source"
+    t.integer "requested_patents_mexico"
+    t.integer "requested_designs_mexico"
+    t.integer "requested_patents_us_eu_as"
+    t.integer "given_patents_mexico"
+    t.integer "given_designs_mexico"
+    t.integer "given_patents_us_eu_as"
+    t.integer "trademarks"
+    t.integer "copyrights"
+    t.integer "isi_publications"
+    t.integer "arbitrated_publications"
+    t.integer "non_arbitrated_publications"
+    t.integer "quotes_in_publications"
+    t.string "director_name"
+    t.string "director_email"
+    t.string "director_phone"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "transfer_office_contact_name"
+    t.string "transfer_office_contact"
   end
 
-  create_table 'clusters', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "centers_clusters", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "cluster_id", null: false
+    t.bigint "center_id", null: false
+    t.index ["center_id"], name: "index_centers_clusters_on_center_id"
+    t.index ["cluster_id"], name: "index_centers_clusters_on_cluster_id"
   end
 
-  create_table 'equipment', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.text 'description'
-    t.boolean 'available'
-    t.bigint 'center_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['center_id'], name: 'index_equipment_on_center_id'
+  create_table "centers_industries", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "industry_id", null: false
+    t.bigint "center_id", null: false
+    t.index ["center_id"], name: "index_centers_industries_on_center_id"
+    t.index ["industry_id"], name: "index_centers_industries_on_industry_id"
   end
 
-  create_table 'idti_areas', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.bigint 'center_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['center_id'], name: 'index_idti_areas_on_center_id'
+  create_table "centro_investigacions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "nombre"
+    t.string "abreviacion"
+    t.string "sitio"
+    t.string "domicilio"
+    t.date "fecha_inicio"
+    t.string "nombre_encargado"
+    t.string "correo_encargado"
+    t.string "telefono_encargado"
+    t.string "sectores"
+    t.string "industrias"
+    t.string "areas_investigacion"
+    t.string "servicios_idti"
+    t.decimal "terreno_total", precision: 10
+    t.decimal "terreno_privada", precision: 10
+    t.decimal "terreno_federal", precision: 10
+    t.decimal "terreno_estatal", precision: 10
+    t.decimal "terreno_otro", precision: 10
+    t.decimal "equip_total", precision: 10
+    t.decimal "equip_privado", precision: 10
+    t.decimal "equip_federal", precision: 10
+    t.decimal "equip_estatal", precision: 10
+    t.decimal "equip_otro", precision: 10
+    t.decimal "area_edificio", precision: 10
+    t.decimal "area_terreno", precision: 10
+    t.decimal "area_total", precision: 10
+    t.decimal "area_idi", precision: 10
+    t.text "lista_equipo"
+    t.text "patentes_solicitadas_mexico"
+    t.text "disenos_solicitados_mexico"
+    t.text "patentes_solicitadas_triadicas"
+    t.text "patentes_otorgadas_mexico"
+    t.text "disenos_otorgados_mexico"
+    t.text "patentes_otorgadas_triadicas"
+    t.text "marcas_registradas"
+    t.text "derechos_registrados"
+    t.text "publicaciones_isi"
+    t.text "articulos_arb"
+    t.text "articulos_no_arb"
+    t.text "citas_articulos"
+    t.text "premios_centro"
+    t.string "responsable_dep_vinculacion"
+    t.bigint "user_id"
+    t.integer "centro_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["centro_id"], name: "index_centro_investigacions_on_centro_id", unique: true
+    t.index ["user_id"], name: "index_centro_investigacions_on_user_id"
   end
 
-  create_table 'idti_services', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.string 'industry'
-    t.bigint 'center_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['center_id'], name: 'index_idti_services_on_center_id'
+  create_table "clusters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'industries', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "equipment", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.boolean "available"
+    t.bigint "center_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["center_id"], name: "index_equipment_on_center_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'role'
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  create_table "idti_areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.bigint "center_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["center_id"], name: "index_idti_areas_on_center_id"
   end
 
-  add_foreign_key 'awards', 'centers'
-  add_foreign_key 'equipment', 'centers'
-  add_foreign_key 'idti_areas', 'centers'
-  add_foreign_key 'idti_services', 'centers'
+  create_table "idti_services", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "industry"
+    t.bigint "center_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["center_id"], name: "index_idti_services_on_center_id"
+  end
+
+  create_table "industries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "role"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  add_foreign_key "awards", "centers"
+  add_foreign_key "centro_investigacions", "users"
+  add_foreign_key "equipment", "centers"
+  add_foreign_key "idti_areas", "centers"
+  add_foreign_key "idti_services", "centers"
 end

--- a/test/fixtures/admin_centers.yml
+++ b/test/fixtures/admin_centers.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/admin_platforms.yml
+++ b/test/fixtures/admin_platforms.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/admin_center_test.rb
+++ b/test/models/admin_center_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdminCenterTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/admin_platform_test.rb
+++ b/test/models/admin_platform_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdminPlatformTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Restrict permissions to create a new Centro de Investigación so that only platform admins and center admins can create a new one. In case a center admin has created a centro de investigación already, they'll be redirected to the edit form instead of being allowed to create a second centro de investigación