### PR TITLE
Fix all users permissions for CRUD Investigation Centers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'jbuilder', '~> 2.5'
 # Use devise for users authentication
 gem 'devise', '~> 4.7', '>= 4.7.1'
 
+# Use CanCanCan for users authorization
+gem 'cancancan'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  # before_action :configure_permitted_parameters, if: :devise_controller?
+  # protected
+  # def configure_permitted_parameters
+  #   devise_parameter_sanitizer.for(:sign_up)  { |u| u.permit(  :email, :password, :password_confirmation, roles: [] ) }
+  # end
 end

--- a/app/controllers/centers_controller.rb
+++ b/app/controllers/centers_controller.rb
@@ -26,7 +26,7 @@ class CentersController < ApplicationController
   # POST /centers.json
   def create
     @center = Center.new(center_params)
-
+    @center.user_id = current_user.id
     respond_to do |format|
       if @center.save
         format.html { redirect_to @center, notice: 'Center was successfully created.' }

--- a/app/controllers/centers_controller.rb
+++ b/app/controllers/centers_controller.rb
@@ -31,6 +31,13 @@ class CentersController < ApplicationController
   # GET /centers/1/edit
   def edit; end
 
+  # Check that the user has the ability to create a new Center and that they haven't
+  # created any centers previously.
+  def can_create_center
+    return (can? :create, Center) && (not Center.exists?(user_id: current_user.id))
+  end
+  helper_method :can_create_center
+
   # POST /centers
   # POST /centers.json
   def create

--- a/app/controllers/centers_controller.rb
+++ b/app/controllers/centers_controller.rb
@@ -35,8 +35,9 @@ class CentersController < ApplicationController
   # POST /centers.json
   def create
     # Don't create a new center if the user already has one.
-    if not Center.exists?(user_id: current_user.id)
-      @center.user_id = current_user.id
+    @current_id = current_user.id
+    if not Center.exists?(user_id: @current_id)
+      @center.user_id = @current_id
       respond_to do |format|
         if @center.save
           format.html { redirect_to @center, notice: 'Center was successfully created.' }

--- a/app/controllers/centers_controller.rb
+++ b/app/controllers/centers_controller.rb
@@ -22,7 +22,7 @@ class CentersController < ApplicationController
   def new
     # Redirect to center edit page if there's already a center created for this account.
     @center_id = Center.find_by(user_id: current_user.id)
-    unless @center_id.nil?
+    if @center_id
       redirect_to edit_center_path(id: @center_id)
     end
     # @center = Center.new

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RegistrationsController < Devise::RegistrationsController
+  def new
+    super
+  end
+
+  def create
+  	super
+  end
+
+  def update
+    super
+  end
+
+  def sign_up_params
+    params.require(:user).permit(:email, :password, :password_confirmation, :role)
+  end
+end

--- a/app/controllers/usuarios_controller.rb
+++ b/app/controllers/usuarios_controller.rb
@@ -2,5 +2,13 @@
 
 # Main controller for responding to user actions.
 class UsuariosController < ApplicationController
-  def inicio; end
+  # before_filter :authenticate_user!
+  def inicio
+  	@users = User.all
+  end
+
+
+  def edit_profile
+    @user = current_user
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
+# Define user permissions according to their role.
 class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # Define abilities for the passed in user here. For example:
-    #
+    # Define abilities for the passed in user here.
     user ||= User.new # guest user (not logged in)
     if user.admin_plataforma?
         can :manage, :all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    user ||= User.new # guest user (not logged in)
+    if user.admin_plataforma?
+        can [:update, :destroy], Center
+        can :manage, User
+        can :read, :all
+    elsif user.admin_centro_inv?
+        can :create, Center  # Can create a new Center.
+        can :manage, Center, user_id: user.id # Can only edit their own Centers.
+        can :read, :all
+    else
+        can :read, :all
+    end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,9 +8,8 @@ class Ability
     #
     user ||= User.new # guest user (not logged in)
     if user.admin_plataforma?
-        can [:update, :destroy], Center
-        can :manage, User
-        can :read, :all
+        can :manage, :all
+        cannot :create, Center  # Can create a new Center.
     elsif user.admin_centro_inv?
         can :create, Center  # Can create a new Center.
         can :manage, Center, user_id: user.id # Can only edit their own Centers.

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,10 +13,8 @@ class Ability
     elsif user.admin_centro_inv?
         can :create, Center  # Can create a new Center.
         can :manage, Center, user_id: user.id # Can only edit their own Centers.
-        can :read, :all
-    else
-        can :read, :all
     end
+    can :read, :all
     #
     # The first argument to `can` is the action you are giving the user
     # permission to do.

--- a/app/models/center.rb
+++ b/app/models/center.rb
@@ -15,4 +15,6 @@ class Center < ApplicationRecord
   accepts_nested_attributes_for :awards, allow_destroy: true, reject_if: ->(attrs) { attrs['name'].blank? }
   accepts_nested_attributes_for :idti_areas, allow_destroy: true, reject_if: ->(attrs) { attrs['name'].blank? }
   accepts_nested_attributes_for :idti_services, allow_destroy: true, reject_if: ->(attrs) { attrs['name'].blank? }
+
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_one :center
 end

--- a/app/views/centers/index.html.erb
+++ b/app/views/centers/index.html.erb
@@ -28,6 +28,6 @@
 
 <br>
 
-<%if can? :create, Center %>
+<%if can_create_center %>
   <%= link_to 'Agregar centro', new_center_path %>
 <% end %>

--- a/app/views/centers/index.html.erb
+++ b/app/views/centers/index.html.erb
@@ -19,8 +19,8 @@
         <td><%= center.short_name %></td>
         <td><%= center.website %></td>
         <td><%= link_to 'Detalle', center %></td>
-        <td><%= link_to 'Editar', edit_center_path(center) %></td>
-        <td><%= link_to 'Destruir', center ,data: { confirm: 'Seguro que quieres destruir el centro?' }, method: :delete %></td>
+        <%if can? :update, center %> <td><%= link_to 'Editar', edit_center_path(center) %></td> <% end %>
+        <%if can? :update, center %> <td><%= link_to 'Destruir', center ,data: { confirm: 'Seguro que quieres destruir el centro?' }, method: :delete %></td> <% end %>
       </tr>
     <% end %>
   </tbody>
@@ -28,4 +28,6 @@
 
 <br>
 
-<%= link_to 'Agregar centro', new_center_path %>
+<%if can? :create, Center %>
+  <%= link_to 'Agregar centro', new_center_path %>
+<% end %>

--- a/app/views/centers/show.html.erb
+++ b/app/views/centers/show.html.erb
@@ -223,5 +223,5 @@
   <% end %>
 </ul>
 
-<%= link_to 'Editar', edit_center_path(@center) %> |
+<%if can? :update, @center %><%= link_to 'Editar', edit_center_path(@center) %> | <% end %>
 <%= link_to 'Regresar', centers_path %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,6 +21,15 @@
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
+  <div class="field">
+    <%= f.label :user_role %><br />
+    <select name="user[role]">
+      <% User::roles.each do |role| %>
+          <option value="<%= role[0] %>"><%= role[0] %></option>
+      <% end %>
+    </select>
+  </div>
+
   <div class="actions">
     <%= f.submit "Sign up" %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,13 +22,15 @@
   </div>
 
   <div class="field">
-    <%= f.label :user_role %><br />
-    <select name="user[role]">
+    <%= f.label :role %><br />
+    <%= f.select(:role, User.roles.keys.map {|role| [role.titleize,role]}) %>
+<!--
+    <select name=f.role>
       <% User::roles.each do |role| %>
           <option value="<%= role[0] %>"><%= role[0] %></option>
       <% end %>
     </select>
-  </div>
+ -->  </div>
 
   <div class="actions">
     <%= f.submit "Sign up" %>

--- a/app/views/usuarios/inicio.html.erb
+++ b/app/views/usuarios/inicio.html.erb
@@ -4,6 +4,34 @@
 
 <%= link_to 'Cerrar Sesión', destroy_user_session_path, method: :delete %>
 
+
+<table>
+  <thead>
+    <tr>
+      <th>Id</th>
+      <th>Correo</th>
+      <th>Rol</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+    <% if current_user.id == user.id%>
+    	<b>
+	<% end %>
+      <tr>
+        <td><%= user.id %></td>
+        <td><%= user.email %></td>
+        <td><%= user.role %></td>
+      </tr>
+    <% if current_user.id == user.id%>
+    	</b>
+	<% end %>
+    <% end %>
+  </tbody>
+</table>
+
 <% else %>
 
 <%= link_to 'Registrarse', new_user_registration_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
   resources :awards
   resources :clusters
   resources :industries
-  devise_for :users
+  devise_for :users,
+             :controllers  => {
+             :registrations => 'registrations',
+             }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20191020233808_add_user_ref_to_centers.rb
+++ b/db/migrate/20191020233808_add_user_ref_to_centers.rb
@@ -1,0 +1,5 @@
+class AddUserRefToCenters < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :centers, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,123 +10,203 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_009_224_604) do
-  create_table 'awards', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.date 'date'
-    t.bigint 'center_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['center_id'], name: 'index_awards_on_center_id'
+ActiveRecord::Schema.define(version: 2019_10_20_233808) do
+
+  create_table "admin_centers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "has_created_center"
+    t.index ["email"], name: "index_admin_centers_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admin_centers_on_reset_password_token", unique: true
   end
 
-  create_table 'centers', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'full_name'
-    t.string 'short_name'
-    t.string 'website'
-    t.string 'address'
-    t.date 'start_date'
-    t.float 'building_area'
-    t.float 'property_area'
-    t.float 'property_private_funding'
-    t.float 'property_federal_funding'
-    t.float 'property_state_funding'
-    t.float 'property_other_funding'
-    t.string 'property_other_source'
-    t.float 'equipment_private_funding'
-    t.float 'equipment_federal_funding'
-    t.float 'equipment_state_funding'
-    t.float 'equipment_other_funding'
-    t.string 'equipment_other_source'
-    t.integer 'requested_patents_mexico'
-    t.integer 'requested_designs_mexico'
-    t.integer 'requested_patents_us_eu_as'
-    t.integer 'given_patents_mexico'
-    t.integer 'given_designs_mexico'
-    t.integer 'given_patents_us_eu_as'
-    t.integer 'trademarks'
-    t.integer 'copyrights'
-    t.integer 'isi_publications'
-    t.integer 'arbitrated_publications'
-    t.integer 'non_arbitrated_publications'
-    t.integer 'quotes_in_publications'
-    t.string 'director_name'
-    t.string 'director_email'
-    t.string 'director_phone'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'transfer_office_contact_name'
-    t.string 'transfer_office_contact'
+  create_table "admin_platforms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admin_platforms_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admin_platforms_on_reset_password_token", unique: true
   end
 
-  create_table 'centers_clusters', id: false, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'cluster_id', null: false
-    t.bigint 'center_id', null: false
-    t.index ['center_id'], name: 'index_centers_clusters_on_center_id'
-    t.index ['cluster_id'], name: 'index_centers_clusters_on_cluster_id'
+  create_table "awards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.date "date"
+    t.bigint "center_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["center_id"], name: "index_awards_on_center_id"
   end
 
-  create_table 'centers_industries', id: false, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'industry_id', null: false
-    t.bigint 'center_id', null: false
-    t.index ['center_id'], name: 'index_centers_industries_on_center_id'
-    t.index ['industry_id'], name: 'index_centers_industries_on_industry_id'
+  create_table "centers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "full_name"
+    t.string "short_name"
+    t.string "website"
+    t.string "address"
+    t.date "start_date"
+    t.float "building_area"
+    t.float "property_area"
+    t.float "property_private_funding"
+    t.float "property_federal_funding"
+    t.float "property_state_funding"
+    t.float "property_other_funding"
+    t.string "property_other_source"
+    t.float "equipment_private_funding"
+    t.float "equipment_federal_funding"
+    t.float "equipment_state_funding"
+    t.float "equipment_other_funding"
+    t.string "equipment_other_source"
+    t.integer "requested_patents_mexico"
+    t.integer "requested_designs_mexico"
+    t.integer "requested_patents_us_eu_as"
+    t.integer "given_patents_mexico"
+    t.integer "given_designs_mexico"
+    t.integer "given_patents_us_eu_as"
+    t.integer "trademarks"
+    t.integer "copyrights"
+    t.integer "isi_publications"
+    t.integer "arbitrated_publications"
+    t.integer "non_arbitrated_publications"
+    t.integer "quotes_in_publications"
+    t.string "director_name"
+    t.string "director_email"
+    t.string "director_phone"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "transfer_office_contact_name"
+    t.string "transfer_office_contact"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_centers_on_user_id"
   end
 
-  create_table 'clusters', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "centers_clusters", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "cluster_id", null: false
+    t.bigint "center_id", null: false
+    t.index ["center_id"], name: "index_centers_clusters_on_center_id"
+    t.index ["cluster_id"], name: "index_centers_clusters_on_cluster_id"
   end
 
-  create_table 'equipment', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.text 'description'
-    t.boolean 'available'
-    t.bigint 'center_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['center_id'], name: 'index_equipment_on_center_id'
+  create_table "centers_industries", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "industry_id", null: false
+    t.bigint "center_id", null: false
+    t.index ["center_id"], name: "index_centers_industries_on_center_id"
+    t.index ["industry_id"], name: "index_centers_industries_on_industry_id"
   end
 
-  create_table 'idti_areas', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.bigint 'center_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['center_id'], name: 'index_idti_areas_on_center_id'
+  create_table "centro_investigacions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "nombre"
+    t.string "abreviacion"
+    t.string "sitio"
+    t.string "domicilio"
+    t.date "fecha_inicio"
+    t.string "nombre_encargado"
+    t.string "correo_encargado"
+    t.string "telefono_encargado"
+    t.string "sectores"
+    t.string "industrias"
+    t.string "areas_investigacion"
+    t.string "servicios_idti"
+    t.decimal "terreno_total", precision: 10
+    t.decimal "terreno_privada", precision: 10
+    t.decimal "terreno_federal", precision: 10
+    t.decimal "terreno_estatal", precision: 10
+    t.decimal "terreno_otro", precision: 10
+    t.decimal "equip_total", precision: 10
+    t.decimal "equip_privado", precision: 10
+    t.decimal "equip_federal", precision: 10
+    t.decimal "equip_estatal", precision: 10
+    t.decimal "equip_otro", precision: 10
+    t.decimal "area_edificio", precision: 10
+    t.decimal "area_terreno", precision: 10
+    t.decimal "area_total", precision: 10
+    t.decimal "area_idi", precision: 10
+    t.text "lista_equipo"
+    t.text "patentes_solicitadas_mexico"
+    t.text "disenos_solicitados_mexico"
+    t.text "patentes_solicitadas_triadicas"
+    t.text "patentes_otorgadas_mexico"
+    t.text "disenos_otorgados_mexico"
+    t.text "patentes_otorgadas_triadicas"
+    t.text "marcas_registradas"
+    t.text "derechos_registrados"
+    t.text "publicaciones_isi"
+    t.text "articulos_arb"
+    t.text "articulos_no_arb"
+    t.text "citas_articulos"
+    t.text "premios_centro"
+    t.string "responsable_dep_vinculacion"
+    t.bigint "user_id"
+    t.integer "centro_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["centro_id"], name: "index_centro_investigacions_on_centro_id", unique: true
+    t.index ["user_id"], name: "index_centro_investigacions_on_user_id"
   end
 
-  create_table 'idti_services', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.string 'industry'
-    t.bigint 'center_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['center_id'], name: 'index_idti_services_on_center_id'
+  create_table "clusters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'industries', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "equipment", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.boolean "available"
+    t.bigint "center_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["center_id"], name: "index_equipment_on_center_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'role'
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  create_table "idti_areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.bigint "center_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["center_id"], name: "index_idti_areas_on_center_id"
   end
 
-  add_foreign_key 'awards', 'centers'
-  add_foreign_key 'equipment', 'centers'
-  add_foreign_key 'idti_areas', 'centers'
-  add_foreign_key 'idti_services', 'centers'
+  create_table "idti_services", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "industry"
+    t.bigint "center_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["center_id"], name: "index_idti_services_on_center_id"
+  end
+
+  create_table "industries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "role"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  add_foreign_key "awards", "centers"
+  add_foreign_key "centers", "users"
+  add_foreign_key "centro_investigacions", "users"
+  add_foreign_key "equipment", "centers"
+  add_foreign_key "idti_areas", "centers"
+  add_foreign_key "idti_services", "centers"
 end


### PR DESCRIPTION
Closes #27 and technically #2 too
- Replaces authorization model with a simple Cancancan abilities
- Links Centros de Investigación to a User account 
- Only admin_centro_inv users can create Centros de Investigación 
- There can only be 1 Centro per User
- Only the user that created that Centros de Investigación can delete or edit (in addition to the admin platform)
- The admin platform can edit and delete everything
- Adds option in the signup form for specifying the User role 